### PR TITLE
Fixed "auto-dragging images" in Firefox

### DIFF
--- a/js/jquery.flips.js
+++ b/js/jquery.flips.js
@@ -566,6 +566,8 @@
 				
 			} );
 			
+			this.$el.on('dragstart','img', function(event) { event.preventDefault(); });
+			
 			this.$flipPages.find( '.box' ).on( 'click.flips', function( event ) {
 				
 				var $box 			= $(this),


### PR DESCRIPTION
Firefox automatically drags images, preventing swipes from registering.
